### PR TITLE
Fix past-winners page route name

### DIFF
--- a/mumbaihackathon_in/public/js/console.js
+++ b/mumbaihackathon_in/public/js/console.js
@@ -148,7 +148,7 @@ class EmuTerm {
 let pages = {
     'rules': '/rules',
     'about': '/about',
-    'winners': '/winners'
+    'winners': '/past-winners'
 }
 
 const t = new EmuTerm(document.getElementById('terminal'), {


### PR DESCRIPTION
`>nav winners` on the console causes this 👇  due to wrong route mapping in the `pages Object` in `mumbaihackathon_in\mumbaihackathon_in\public\js\console.js`.

![page-not-found](https://user-images.githubusercontent.com/20588777/53755923-cc6e8380-3edd-11e9-9336-b6a918b21911.png)


This hopefully fixes it :  
`mumbaihackathon_in\mumbaihackathon_in\public\js\console.js`
 ```diff
 - 'winners': '/winners'
 + 'winners': '/past-winners'
 ```